### PR TITLE
Changed link to sqlite3 driver lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Integration tests are tagged with `+integration`, so if you want to run them you
 ```bash
 go test -tags=integration
 ```
-_If  integration tests takes too long remember to_ `go install code.google.com/p/go-sqlite/go1/sqlite3`
+_If  integration tests takes too long remember to_ `go install github.com/mxk/go-sqlite/sqlite3`
 
 Otherwise just run:
 ```bash

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "code.google.com/p/go-sqlite/go1/sqlite3"
+	_ "github.com/mxk/go-sqlite/sqlite3"
 )
 
 func initDotSql() (*sql.DB, *DotSql) {


### PR DESCRIPTION
sqlite3 library has been moved from code.google.com to github.com